### PR TITLE
ci: remove borales/actions-yarn from unit-tests workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,9 +10,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
-      - name: Install yarn
-        uses: borales/actions-yarn@v4
-        with:
-          cmd: install
+      - run: corepack enable
+      - name: Install dependencies
+        run: yarn install
       - run: npm run build
       - run: npm run test

--- a/package.json
+++ b/package.json
@@ -40,5 +40,6 @@
     "test": "node --test",
     "bench": "node tests/benchmark.js"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
## What

Removes `borales/actions-yarn@v4` from `.github/workflows/unit-tests.yml`. Replaces it with `corepack enable` + a direct `yarn install` step.

To make corepack deterministic, this PR also adds `"packageManager": "yarn@1.22.22"` to `package.json` — without that field, `corepack enable` only installs shims and would resolve yarn from a built-in default rather than a pinned version.

(`publish-npmjs.yml` is unchanged — it only uses `actions/*` already.)

## Why

`borales/actions-yarn` is a third-party action that ran in the unit-tests workflow with access to job secrets. It does nothing that `corepack enable` + `yarn install` doesn't do natively. Pinning the yarn version via `packageManager` makes the build reproducible and matches the convention used in the other Railgun repos.